### PR TITLE
merging a vendor request to filter addressList by addresses that do not have a state/prefecture

### DIFF
--- a/deploy/src/perihelion/php/model/address.model.php
+++ b/deploy/src/perihelion/php/model/address.model.php
@@ -113,6 +113,7 @@ class Address extends ORM {
 		$where[] = 'biomass_Report.siteID = :siteID';
 		$where[] = 'perihelion_Address.deleted = 0';
 		$where[] = 'perihelion_Address.addressDefault = 1';
+		$where[] = 'perihelion_Address.state != ""';
 
 		$query = 'SELECT DISTINCT state FROM perihelion_Address LEFT JOIN biomass_Report 
 		ON perihelion_Address.addressObjectID = biomass_Report.shopID WHERE ' . implode(' AND ', $where) . '';


### PR DESCRIPTION
we need to move this function into its own class and provide it with its own arguments/parameters _but_ as this function is currently only used in the system that the vendor is working on and they require it to avoid a project refactor i'll let it through.

please note that we should not rely on `Address::stateList()` in other systems as it will be refactored into its own class soon

reference: https://github.com/chishiki/perihelion/commit/4908d9e028f52267ea320101d46504e99fac9d68#diff-65f96a589e41cb8559ef738115bd85b2dfec13f740fa5afc717157c3b54ae3c5

